### PR TITLE
Update producers reducer with new changes in backend

### DIFF
--- a/src/containers/Group/Suppliers/Base.js
+++ b/src/containers/Group/Suppliers/Base.js
@@ -6,8 +6,8 @@ import { asyncConnect } from 'redux-async-connect';
 
 import CreateProducerForm from 'components/forms/producers/Create';
 import { load as loadSuppliers } from 'redux/modules/suppliers/list';
-import { load as loadProducers } from 'redux/modules/producers/list';
-import { create } from 'redux/modules/producers/list';
+import { load as loadProducers } from 'redux/modules/producers/producers';
+import { create } from 'redux/modules/producers/producers';
 import { suppliersWithProducerSelector } from 'selectors/producers';
 import List from './List';
 
@@ -28,7 +28,7 @@ const mapDispatchToProps = { initialize, create };
 
     const promises = [];
     promises.push(dispatch(loadSuppliers(id)));
-    promises.push(dispatch(loadProducers()));
+    promises.push(dispatch(loadProducers(id)));
 
     return Promise.all(promises);
   },

--- a/src/containers/Group/Suppliers/Details/index.js
+++ b/src/containers/Group/Suppliers/Details/index.js
@@ -3,7 +3,7 @@ import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';
 
-import { loadEntity as loadProducer } from 'redux/modules/producers/list';
+import { loadEntity as loadProducer } from 'redux/modules/producers/producers';
 
 const mapStateToProps = (state, ownProps) => {
   const producerId = ownProps.params.producer_id;

--- a/src/redux/modules/producers/producers.js
+++ b/src/redux/modules/producers/producers.js
@@ -11,7 +11,7 @@ const CREATE_PRODUCER_SUCCESS = 'redux-example/producers/CREATE_PRODUCER_SUCCESS
 const CREATE_PRODUCER_FAIL = 'redux-example/producers/CREATE_PRODUCER_FAIL';
 
 const initialState = {
-  producers: {entities: []},
+  producers: { entities: [] },
   createProducerErrors: {},
 };
 
@@ -107,10 +107,10 @@ export default function producersReducer(state = initialState, action = {}) {
   }
 }
 
-export function load() {
+export function load(groupId) {
   return {
     types: [LOAD, LOAD_SUCCESS, LOAD_FAIL],
-    promise: (client) => client.get(`/producers`)
+    promise: (client) => client.get(`/producers?group_id=${groupId}`)
   };
 }
 
@@ -124,9 +124,6 @@ export function loadEntity(id) {
 export function create(data) {
   return {
     types: [CREATE_PRODUCER, CREATE_PRODUCER_SUCCESS, CREATE_PRODUCER_FAIL],
-    promise: (client) => client.post('/producers', {
-      data: _.omit(data, 'group_id'),
-      header: { key: 'X-katuma-group-id-for-provider', value: data.group_id },
-    })
+    promise: (client) => client.post('/producers', { data })
   };
 }

--- a/src/redux/modules/reducer.js
+++ b/src/redux/modules/reducer.js
@@ -11,7 +11,7 @@ import completeInvitationReducer, { COMPLETE_INVITATION_SUCCESS }from './invitat
 import invitationsReducer from './invitations/list';
 import groupsReducer from './groups/groups';
 import suppliersReducer from './suppliers/list';
-import producersReducer from './producers/list';
+import producersReducer from './producers/producers';
 import {reducer as form} from 'redux-form';
 import { routeReducer } from 'react-router-redux';
 import {reducer as reduxAsyncConnect} from 'redux-async-connect';


### PR DESCRIPTION
```
GET /api/v1/producers?group_id=27
```

**Response body:** will include all the producers related to the group with id `27` through both `Membership` and `Supplier` relations
**Permissions:** only `admin` and `members` of the group with id `27` can perform this request

```
POST /api/v1/producers
{
  group_id: 27,
  name: 'El pep de les patates',
  email: 'pep@katuma.org',
  address: 'c/ de les patates, 89, Barcelona'
}
```

**Response body:** the resource created
**Permissions:** only `admin` of the group with id `27` can perform this request
